### PR TITLE
Clean up background script and manifest

### DIFF
--- a/extension/mama2.crx/background.js
+++ b/extension/mama2.crx/background.js
@@ -1,5 +1,3 @@
 chrome.browserAction.onClicked.addListener(function(){	
-	chrome.tabs.getSelected(function(tab){
-		chrome.tabs.executeScript(tab.id, {file: "content_script.js"});
-	});
+  chrome.tabs.executeScript(null, {file: "content_script.js"});
 });

--- a/extension/mama2.crx/manifest.json
+++ b/extension/mama2.crx/manifest.json
@@ -1,19 +1,19 @@
 {
-	"name": "MAMA2",
-	"version": "2.0",
-	"manifest_version": 2,
-	"permissions": ["MAMA2"],
-	"browser_action": {
-	  "default_icon": "icon64.png"
-	},
-	"icons": {
-		"16": "icon16.png",
-       	"48": "icon48.png",
-      	"128": "icon128.png"
-	},
-	"background": {
-		"scripts": ["background.js"],
-		"persistent": false
-	},
-	"permissions": ["tabs","notifications","http://*/*","https://*/*"]
+  "name": "MAMA2",
+  "version": "2.0",
+  "manifest_version": 2,
+  "permissions": ["MAMA2"],
+  "browser_action": {
+    "default_icon": "icon64.png"
+  },
+  "icons": {
+    "16": "icon16.png",
+    "48": "icon48.png",
+    "128": "icon128.png"
+  },
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "permissions": ["tabs","notifications","http://*/*","https://*/*"]
 }


### PR DESCRIPTION
`chrome.tabs.executeScript(null, callback)` 作用于当前 Active Tab 所以没必要再套一层了。而且 `chrome.tabs.getSelected` 已经 deprecated 了。

你的 `manifest.json` permission 写了两遍。
Tab 和 space 混用所以我就换成 2-spaces 了。