### PR TITLE
关于外站播放器播放的想法以及简单Demo

### DIFF
--- a/src/seeker_youku.js
+++ b/src/seeker_youku.js
@@ -5,7 +5,21 @@ var canPlayM3U8 = require('./canPlayM3U8')
 var ajax        = require('./ajax')
 var log         = require('./log')
 exports.match = function (url) {
-	return /v\.youku\.com/.test(url.attr('host')) && !!window.videoId
+	var embeds = document.getElementsByTagName('embed');
+	var youkuReg = /http:\/\/player\.youku\.com\/player\.php\/sid\/(.*)\/v\.swf/;
+	for(var i = 0, len = embeds.length; i < len; i++) {//暂时只播放第一个Flash视频
+		var src = embeds[i]['src'];
+		var embedType = embeds[i]['type'];
+		if (embedType === 'application/x-shockwave-flash' && typeof src === 'string'){
+			var match = youkuReg.exec(src);
+			if (!(match[1])){//match[1]存放视频ID，如XOTUzNDA1NTQ4
+				break;
+			}
+			window.videoId = match[1];//绑定视频ID，竟然就直接可以用
+			return true;
+		}
+	}
+	return /v\.youku\.com/.test(url.attr('host')) && !!window.videoId;
 }
 var parseYoukuCode = exports.parseYoukuCode = function (_id, callback) {
 	log('开始解析youku视频地址')	


### PR DESCRIPTION
这是一个Demo，用优酷举例子

很多外站里面总会有利用主站JS生成的播放器，这些播放器没装Flash肯定播放不了，但是最可怕的是跳转到主站链接的按钮很多都是放在Flash里面的，所以导致很多时候必
须先拿Chrome跳转到主站，复制粘贴URL到Safari，再看。非常麻烦……

这里给了一个Demo用来说明我的意思，就是开Safari在一个页面，点击MAMA2，直接播放当前页Flash视频，不用非到Youku主站访问……

如果有兴趣的话求前端页面资助，给用户选择播放第几个视频资源（如果外站一个页面有多个Flash视频的话，甚至是不同来源的Flash视频，比如一个页
面有Youku也有土豆）

可以用简单的网页测试
http://www.igeek.com.cn/portal.php?mod=view&aid=10227